### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.*.swp
+.*.swo
+*.hi
+*.o
+*.exe
+arata
+arata.conf
+db
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM flitter/init
+
+RUN apt-get update &&\
+    apt-get install -y ghc cabal-install make
+
+RUN cabal update &&\
+    cabal install connection &&\
+    cabal install acid-state &&\
+    cabal install configfile &&\
+    cabal install mtl &&\
+    cabal install containers &&\
+    cabal install ixset
+
+ADD . /arata
+
+RUN cd /arata && make build
+
+ADD target/docker/arata /etc/service/arata/run
+
+CMD /sbin/my_init

--- a/target/docker/arata
+++ b/target/docker/arata
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Default to default gateway
+IP=$(/sbin/ip route | awk '/default/ { print $3 }')
+
+export ARATA_HOST=$IP
+
+if ! [ -z "$IRCD_PORT_6697_TCP_ADDR" ]; then
+	ARATA_HOST=$IRCD_PORT_6697_TCP_ADDR
+fi
+
+cd /arata
+
+sed s/127.0.0.1/"$ARATA_HOST"/g arata.conf.example > arata.conf
+
+./arata


### PR DESCRIPTION
This allows people to easily run Arata inside docker for local evaluation or for people who don't want to install the haskell dependencies on their system. This also makes deployment easier (sans the database, but that can be worked on in the future).
