### PR TITLE
Fix the Docker build, cache dependencies separately

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,16 @@ RUN apt-get update &&\
     apt-get install -y make ghc cabal-install
 
 RUN cabal update
-RUN cd /arata && cabal install
 
-ADD dist /arata
+# Cache the dependencies discretely
+ADD arata.cabal /arata/arata.cabal
+RUN cd /arata && cabal install --only-dependencies
+
+ADD . /arata/src
+RUN cd /arata/src && cabal install &&\
+    cp dist/* -vrf .. &&\
+    rm -rf /arata/src /arata/arata.cabal
+
 ADD target/docker/arata /etc/service/arata/run
 
 CMD /sbin/my_init

--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,7 @@ clean:
 	find src -name '*.o' -print0 | xargs -0 rm -fv
 	find src -name '*.hi' -print0 | xargs -0 rm -fv
 	rm -fv $(EXECUTABLE)
+
+.PHONY: register
+register:
+	true


### PR DESCRIPTION
As requested by @shockkolate in IRC, I have evaluated and fixed the Docker build for Arata. This will cache the depdendencies for Arata separate from the main program code so that the image will build faster.
