### PR TITLE
Add plugins to dist tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 install: build
 	mkdir -p dist
 	cp -v arata arata.conf.example dist/
+	cp -rfv plugins dist/
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Fixes a discovered problem with plugins not being added on an installed
instance of Arata.
