### PR TITLE
gitignore uses absolute paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,9 @@
 *.hi
 *.o
 *.exe
-cabal.sandbox.config
-.cabal-sandbox
-dist
-arata
-arata.conf
-db
+/cabal.sandbox.config
+/.cabal-sandbox
+/dist
+/arata
+/arata.conf
+/db


### PR DESCRIPTION
Fixes a minor issue noticed while developing the testnet in a box for arata testing.
