### PR TITLE
Arata/Helper: add clientIsOper

### DIFF
--- a/src/Arata/Helper.hs
+++ b/src/Arata/Helper.hs
@@ -79,6 +79,9 @@ getClientByNick nick' = gets clients >>= return . M.filter (pred' . nick) >>= \c
 addClient :: Client -> Arata ()
 addClient cli = modify (\env -> env { clients = M.insert (uid cli) cli (clients env) })
 
+clientIsOper :: Client -> Bool
+clientIsOper cli = 'o' `elem` userModes cli
+
 firstAvailableID :: Arata Integer
 firstAvailableID = queryDB QueryAccounts >>= return . f 1 . map accId . Ix.toAscList (Ix.Proxy :: Ix.Proxy Integer)
   where


### PR DESCRIPTION
A simple function that takes in a client and returns if it has user mode `+o` or not.

ref https://tools.ietf.org/html/rfc1459#section-4.2.3.2
